### PR TITLE
Fix for application context path handling: -

### DIFF
--- a/slackIntegration-server/src/main/resources/buildServerResources/buildPage.jsp
+++ b/slackIntegration-server/src/main/resources/buildServerResources/buildPage.jsp
@@ -1,14 +1,12 @@
 <%@ include file="/include.jsp" %>
 
 <script type="text/javascript">
-    var rootUrl = "${serverSummary.rootURL}/".replace(/^https?:\/\//, '').split('/', 2)[1];
-
     window.slackNotifier = {
-       buildSettingListUrl: rootUrl + "${buildSettingListUrl}?buildTypeId=${buildTypeId}",
-       buildSettingEditUrl: rootUrl + "${buildSettingEditUrl}?buildTypeId=${buildTypeId}",
-       buildSettingTryUrl: rootUrl + "${buildSettingTryUrl}",
-       buildSettingSaveUrl: rootUrl + "${buildSettingSaveUrl}?buildTypeId=${buildTypeId}",
-       buildSettingDeleteUrl: rootUrl + "${buildSettingDeleteUrl}"
+       buildSettingListUrl: "${buildSettingListUrl}?buildTypeId=${buildTypeId}",
+       buildSettingEditUrl: "${buildSettingEditUrl}?buildTypeId=${buildTypeId}",
+       buildSettingTryUrl: "${buildSettingTryUrl}",
+       buildSettingSaveUrl: "${buildSettingSaveUrl}?buildTypeId=${buildTypeId}",
+       buildSettingDeleteUrl: "${buildSettingDeleteUrl}"
     };
 </script>
 

--- a/slackIntegration-server/src/main/resources/buildServerResources/configPage.jsp
+++ b/slackIntegration-server/src/main/resources/buildServerResources/configPage.jsp
@@ -1,9 +1,11 @@
 <%@ include file="/include.jsp" %>
 
+<c:url value="${saveConfigSubmitUrl}" var="submitUrl"/>
+
 <c:if test="${not empty error}">
     <b>${error}</b>
 </c:if>
-<form action="${serverSummary.rootURL}/app/slackIntegration/config" method="post">
+<form action="${submitUrl}" method="post">
     <table class="runnerFormTable">
         <tbody>
             <tr>

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/Resources.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/Resources.scala
@@ -4,16 +4,25 @@ object Resources {
 
   case class View(view: String)
 
-  case class Action(url: String)
+  case class Action(url: String) {
+    lazy val controllerUrl = withLeadingSlash(url)
+  }
 
-  case class Page(url: String, view: String)
+  case class Page(url: String, view: String) {
+    lazy val controllerUrl = withLeadingSlash(url)
+  }
+
+  private def withLeadingSlash(url: String) = {
+    if (url.startsWith("/")) url
+    else s"/$url"
+  }
 
   lazy val buildPage = View("buildPage.jsp")
-  lazy val buildSettingList = Page("/app/slackIntegration/buildSettingList.html", "buildSettingListPage.jsp")
-  lazy val buildSettingEdit = Page("/app/slackIntegration/buildSettingEdit.html", "buildSettingEditPage.jsp")
-  lazy val buildSettingSave = Action("/app/slackIntegration/buildSettingSave.html")
-  lazy val buildSettingDelete = Action("/app/slackIntegration/buildSettingDelete.html")
-  lazy val buildSettingTry = Action("/app/slackIntegration/buildSettingTry.html")
-  lazy val configPage = Page("/app/slackIntegration/config", "configPage.jsp")
+  lazy val buildSettingList = Page("app/slackIntegration/buildSettingList.html", "buildSettingListPage.jsp")
+  lazy val buildSettingEdit = Page("app/slackIntegration/buildSettingEdit.html", "buildSettingEditPage.jsp")
+  lazy val buildSettingSave = Action("app/slackIntegration/buildSettingSave.html")
+  lazy val buildSettingDelete = Action("app/slackIntegration/buildSettingDelete.html")
+  lazy val buildSettingTry = Action("app/slackIntegration/buildSettingTry.html")
+  lazy val configPage = Page("app/slackIntegration/config", "configPage.jsp")
   lazy val ajaxView = View("ajaxView.jsp")
 }

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsDelete.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsDelete.scala
@@ -14,7 +14,7 @@ class BuildSettingsDelete(configManager: ConfigManager,
                          )
   extends SlackController {
 
-  controllerManager.registerController(Resources.buildSettingDelete.url, this)
+  controllerManager.registerController(Resources.buildSettingDelete.controllerUrl, this)
 
   override def handle(request: HttpServletRequest, response: HttpServletResponse): ModelAndView = {
     val result = for {

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsSave.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsSave.scala
@@ -19,7 +19,7 @@ class BuildSettingsSave(val configManager: ConfigManager,
                        )
   extends SlackController {
 
-  controllerManager.registerController(Resources.buildSettingSave.url, this)
+  controllerManager.registerController(Resources.buildSettingSave.controllerUrl, this)
 
   override def handle(request: HttpServletRequest, response: HttpServletResponse): ModelAndView =
     ajaxView(handleSave(request))

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsTry.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsTry.scala
@@ -31,7 +31,7 @@ class BuildSettingsTry(buildHistory: BuildHistory,
   import BuildSettingsTry._
   import Strings.BuildSettingsTry._
 
-  controllerManager.registerController(Resources.buildSettingTry.url, this)
+  controllerManager.registerController(Resources.buildSettingTry.controllerUrl, this)
 
   override def handle(request: HttpServletRequest, response: HttpServletResponse): ModelAndView = Try {
     val id = request.param("id")

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/ConfigController.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/ConfigController.scala
@@ -20,7 +20,7 @@ class ConfigController(
   import ConfigController._
   import Helpers.Implicits._
 
-  controllerManager.registerController(Resources.configPage.url, this)
+  controllerManager.registerController(Resources.configPage.controllerUrl, this)
 
   override def handle(request: HttpServletRequest, response: HttpServletResponse): ModelAndView = {
     val result = for {
@@ -47,13 +47,13 @@ class ConfigController(
 
     val either = result.getOrElse(Right(oauthKeyParamMissing))
 
-    redirectTo(createRedirect(either), response)
+    redirectTo(createRedirect(either, request.getContextPath), response)
   }
 }
 
 object ConfigController {
-  private def createRedirect(either: Either[Boolean, String]): String = either match {
-    case Left(_) ⇒ s"/admin/admin.html?item=${Strings.tabId}"
-    case Right(error) ⇒ s"/admin/admin.html?item=${Strings.tabId}&error=${URLEncoder.encode(error, "UTF-8")}"
+  private def createRedirect(either: Either[Boolean, String], context: String): String = either match {
+    case Left(_) ⇒ s"$context/admin/admin.html?item=${Strings.tabId}"
+    case Right(error) ⇒ s"$context/admin/admin.html?item=${Strings.tabId}&error=${URLEncoder.encode(error, "UTF-8")}"
   }
 }

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/pages/BuildSettingEditPage.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/pages/BuildSettingEditPage.scala
@@ -15,7 +15,7 @@ class BuildSettingEditPage(controllerManager: WebControllerManager,
                            val permissionManager: PermissionManager,
                            config: ConfigManager
                           ) extends SlackController {
-  controllerManager.registerController(Resources.buildSettingEdit.url, this)
+  controllerManager.registerController(Resources.buildSettingEdit.controllerUrl, this)
 
   override def handle(request: HttpServletRequest, response: HttpServletResponse): ModelAndView = {
     import com.fpd.teamcity.slack.Helpers.Implicits._

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/pages/BuildSettingListPage.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/pages/BuildSettingListPage.scala
@@ -18,7 +18,7 @@ class BuildSettingListPage(controllerManager: WebControllerManager,
                            val permissionManager: PermissionManager,
                            projectManager: ProjectManager
                           ) extends BaseController with SlackController {
-  controllerManager.registerController(Resources.buildSettingList.url, this)
+  controllerManager.registerController(Resources.buildSettingList.controllerUrl, this)
 
   override def handle(request: HttpServletRequest, response: HttpServletResponse): ModelAndView = {
     val view = descriptor.getPluginResourcesPath(Resources.buildSettingList.view)

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/pages/ConfigPage.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/pages/ConfigPage.scala
@@ -31,6 +31,7 @@ class ConfigPage(
 
     model.putAll(extension.details.mapValues(_.getOrElse("")).asJava)
     model.put("error", request.param("error").getOrElse(""))
+    model.put("saveConfigSubmitUrl", Resources.configPage.controllerUrl)
   }
 
   override def getGroup: String = Groupable.SERVER_RELATED_GROUP


### PR DESCRIPTION
* Remove leading forward slash of URLs passed to the UI to prevent loss of context path when used in ajaxUpdater, whilst retaining the slash in controller registration.
* Update the config page form submit url to use JSTL's URL tag which re-writes it with the application context path.
* Update config page admin redirect URL to include the context path.

Closes #53
