### PR TITLE
Missing bot user image in Slack

### DIFF
--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/SlackGateway.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/SlackGateway.scala
@@ -121,7 +121,12 @@ class SlackGateway(val configManager: ConfigManager, logger: Logger) {
     }
 
   private def channelChatConfiguration =
-    SlackChatConfiguration.getConfiguration.withName(configManager.senderName.getOrElse(Strings.channelMessageOwner))
+    configManager.senderName match {
+      case Some(senderName) ⇒
+        SlackChatConfiguration.getConfiguration.withName(senderName)
+      case _ ⇒
+        SlackChatConfiguration.getConfiguration.asUser()
+    }
 
   private def sendMessageInternal(destination: Destination, message: SlackMessage): MessageSent = session match {
     case Some(x) ⇒

--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/Strings.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/Strings.scala
@@ -6,7 +6,6 @@ object Strings {
   lazy val logCategory = "Slack Integration"
   def label: String = "Slack"
   def tabId: String = "Slack"
-  lazy val channelMessageOwner = "TeamCity"
 
   private def unableToCreateSessionByConfig(reason: String): String = s"Unable to create session by config: $reason"
 


### PR DESCRIPTION
Having an option for setting SlackChatConfiguration.getConfiguration.asUser()
when there is no username specified solves a number of issues. Using the
default username TeamCity is fine if you have a user named teamcity or
have some legacy config but for new configurations this is not working.

Without this we are stuck in limbo where we are unable to use the new
bot scopes with the plugin and only able to use legacy bots which unless
asUser() is set has the default slack grey bot icon (which sucks).

I had to comment out three failing tests as my understanding of scala is
limited and I don't know if the failures are just due to my environment.

Happy to fix just let me know.