### PR TITLE
fix: java.lang.NullPointerException at BuildSettingsTry.scala:96

### DIFF
--- a/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsTry.scala
+++ b/slackIntegration-server/src/main/scala/com/fpd/teamcity/slack/controllers/BuildSettingsTry.scala
@@ -91,13 +91,14 @@ class BuildSettingsTry(
 object BuildSettingsTry {
   @tailrec
   def filterMatchBuild(
-      setting: BuildSetting
-  )(build: SFinishedBuild): Option[SFinishedBuild] = {
+      setting: BuildSetting,
+      build: SFinishedBuild
+  ): Option[SFinishedBuild] = {
     if (!build.isPersonal && build.matchBranch(setting.branchMask))
       Some(build)
     else {
       Option(build.getPreviousFinished) match {
-        case Some(previous) => filterMatchBuild(setting)(previous)
+        case Some(previous) => filterMatchBuild(setting, previous)
         case None           => None
       }
     }
@@ -111,9 +112,9 @@ object BuildSettingsTry {
       projectManager.findBuildTypes(Vector(setting.buildTypeId).asJava)
     val foundBuildType = buildTypes.asScala.headOption
 
-    foundBuildType.flatMap(buildType =>
-      filterMatchBuild(setting)(buildType.getLastChangesFinished)
-    )
+    foundBuildType
+      .flatMap(buildType => Option(buildType.getLastChangesFinished))
+      .flatMap(build => filterMatchBuild(setting, build))
   }
 
   def detectDestination(

--- a/slackIntegration-server/src/test/scala/com/fpd/teamcity/slack/controllers/BuildSettingsTryTest.scala
+++ b/slackIntegration-server/src/test/scala/com/fpd/teamcity/slack/controllers/BuildSettingsTryTest.scala
@@ -55,7 +55,7 @@ class BuildSettingsTryTest extends AnyFlatSpec with MockFactory with Matchers {
           buildSetting: BuildSetting,
           found: Option[SFinishedBuild]
       ) =>
-        BuildSettingsTry.filterMatchBuild(buildSetting)(build) shouldEqual found
+        BuildSettingsTry.filterMatchBuild(buildSetting, build) shouldEqual found
     }
 
     def data =


### PR DESCRIPTION
```
Error java.lang.NullPointerException
	at com.fpd.teamcity.slack.controllers.BuildSettingsTry$.filterMatchBuild(BuildSettingsTry.scala:96)
	at com.fpd.teamcity.slack.controllers.BuildSettingsTry$.$anonfun$findPreviousBuild$1(BuildSettingsTry.scala:115)
	at scala.Option.flatMap(Option.scala:283)
	at com.fpd.teamcity.slack.controllers.BuildSettingsTry$.findPreviousBuild(BuildSettingsTry.scala:114)
```