### PR TITLE
feat: Slack only proxy added

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The plugin automatically backs up its settings after each modification.
 3. [Message placeholders](#message-placeholders)
 4. [Artifact links](#artifact-links)
 5. [Message preview](#message-preview)
-6. [Troubleshooting](#troubleshooting)
+6. [Proxy setup](#proxy-setup)
+7. [Troubleshooting](#troubleshooting)
 
 ## Install plugin <a name="install-plugin"></a>
 Download from [releases](https://github.com/alexkvak/teamcity-slack/releases) or compile 
@@ -148,6 +149,42 @@ Now Slack messages look like
 
 The message is prepended by Emoji ✅, ⛔ or ⚪ for successful, failed and other build statuses respectively.
 
+
+## Proxy setup <a name="proxy-setup"></a>
+Plugin fist lookup for Slack only proxy setting than uses default Java proxy. You can set up proxy by specifying JVM properties:
+
+```
+# proxy specified only for Slack 
+teamcity.slack.proxyHost=proxy.com
+teamcity.slack.proxyPort=8888
+
+# global JVM proxy
+http.proxyHost=proxy.com
+http.proxyPort=8888
+
+# or
+https.proxyHost=proxy.com
+https.proxyPort=8888 
+```
+
+The second way is to set up TeamCity internal properties (see https://www.jetbrains.com/help/teamcity/configuring-teamcity-server-startup-properties.html).
+In this case `teamcity.` prefix should be added.
+
+```
+# proxy specified only for Slack 
+teamcity.slack.proxyHost=proxy.com
+teamcity.slack.proxyPort=8888
+
+# global JVM proxy
+teamcity.http.proxyHost=proxy.com
+teamcity.http.proxyPort=8888
+
+# or
+teamcity.https.proxyHost=proxy.com
+teamcity.https.proxyPort=8888
+```
+
+In both ways the `proxyPort` property can be omitted and port `80` is used by default.
 
 ## Troubleshooting <a name="troubleshooting"></a>
 

--- a/slackIntegration-server/pom.xml
+++ b/slackIntegration-server/pom.xml
@@ -53,8 +53,8 @@
 
         <dependency>
             <groupId>com.slack.api</groupId>
-            <artifactId>bolt-socket-mode</artifactId>
-            <version>1.6.2</version>
+            <artifactId>slack-api-client</artifactId>
+            <version>1.8.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/slackIntegration-server/src/test/scala/com/fpd/teamcity/slack/SlackGatewayTest.scala
+++ b/slackIntegration-server/src/test/scala/com/fpd/teamcity/slack/SlackGatewayTest.scala
@@ -1,0 +1,94 @@
+package com.fpd.teamcity.slack
+
+import jetbrains.buildServer.serverSide.ServerPaths
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SlackGatewayTest
+    extends AnyFlatSpec
+    with MockFactory
+    with Matchers
+    with BeforeAndAfterEach {
+
+  override def beforeEach() {
+    System.clearProperty("slack.proxyHost")
+    System.clearProperty("slack.proxyPort")
+    System.clearProperty("http.proxyHost")
+    System.clearProperty("http.proxyPort")
+    System.clearProperty("https.proxyHost")
+    System.clearProperty("https.proxyPort")
+    super.beforeEach() // To be stackable, must call super.beforeEach
+  }
+
+  "SlackGateway.prepareConfig" should "return config without proxy" in {
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual null
+  }
+
+  "SlackGateway.prepareConfig" should "return config with slack proxy host" in {
+    System.setProperty("slack.proxyHost", "proxy.com")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:80"
+  }
+
+  "SlackGateway.prepareConfig" should "return config with slack proxy host and port" in {
+    System.setProperty("slack.proxyHost", "proxy.com")
+    System.setProperty("slack.proxyPort", "1234")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:1234"
+  }
+
+  "SlackGateway.prepareConfig" should "return config with slack proxy host and ignore non-number port" in {
+    System.setProperty("slack.proxyHost", "proxy.com")
+    System.setProperty("slack.proxyPort", "wrong port")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:80"
+  }
+
+  "SlackGateway.prepareConfig" should "return config with teamcity proxy host" in {
+    System.setProperty("http.proxyHost", "proxy.com")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:80"
+  }
+
+  "SlackGateway.prepareConfig" should "return config with teamcity proxy host and port" in {
+    System.setProperty("http.proxyHost", "proxy.com")
+    System.setProperty("http.proxyPort", "1234")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:1234"
+  }
+
+  "SlackGateway.prepareConfig" should "return config with teamcity proxy host (https)" in {
+    System.setProperty("https.proxyHost", "proxy.com")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:80"
+  }
+
+  "SlackGateway.prepareConfig" should "return config with teamcity proxy host and port (https)" in {
+    System.setProperty("https.proxyHost", "proxy.com")
+    System.setProperty("https.proxyPort", "1234")
+    val config = SlackGateway.prepareConfig
+
+    config.getProxyUrl shouldEqual "http://proxy.com:1234"
+  }
+
+  "SlackGateway" should "be instantiated with proxy" in {
+    System.setProperty("slack.proxyHost", "proxy.com")
+    System.setProperty("slack.proxyPort", "wrong port")
+
+    val serverPaths = new ServerPaths("", "", "", "")
+    val configManager = new ConfigManager(serverPaths)
+    val logger = stub[Logger]
+
+    new SlackGateway(configManager, logger)
+  }
+}


### PR DESCRIPTION
Additionally `bolt-socket-mode` is replaced by `slack-api-client` while the last is enough.

Closes #124.